### PR TITLE
Minor fixes in header

### DIFF
--- a/nextjs-app/src/app/variables.scss
+++ b/nextjs-app/src/app/variables.scss
@@ -7,6 +7,8 @@ $header-border-color: #000;
 $footer-color: #245406;
 $bg-color: #edfbdb;
 $gray-500: #5e6063;
+$btn-auth: #f6f4bc;
+$btn-auth-hover: #fce76c;
 $btn-default: #ffbc0f;
 $btn-hover: #96a300;
 

--- a/nextjs-app/src/components/Header/Header.jsx
+++ b/nextjs-app/src/components/Header/Header.jsx
@@ -146,7 +146,7 @@ const HamburgerMenu = () => {
                         <ul className={styles.hamburgerNavList}>
                             {links.map((link) => (
                                 <li className={styles.navItem} key={link.href}>
-                                    <NavLink href={link.href}>
+                                    <NavLink key={link.href} href={link.href}>
                                         {link.name}
                                     </NavLink>
                                 </li>

--- a/nextjs-app/src/components/Header/header.module.scss
+++ b/nextjs-app/src/components/Header/header.module.scss
@@ -55,11 +55,20 @@
 .navBarLinkActive {
     color: $font-color-main;
     font-weight: 700;
-    // TODO: Underline doesn't work properly when text is placed in multiple lines
-    text-decoration: underline;
-    text-underline-offset: 0.7rem;
-    text-decoration-thickness: 2px;
+    position: relative;
     transition: 0.5s;
+    text-decoration: none;
+
+    &::after {
+        content: '';
+        position: absolute;
+        left: 0;
+        bottom: -5px;
+        width: 100%;
+        height: 2px;
+        /* Толщина подчёркивания */
+        background-color: $font-color-main;
+    }
 
     &:hover {
         text-shadow: 1px 0 0 $font-color-main;
@@ -107,7 +116,7 @@
     left: 0;
     width: 100%;
     border-top: 0.1rem solid rgba(0, 0, 0, 0.5);
-    // TODO: Looks awful. Need fix
+    // TODO: Looks 🤷‍♂️. Need fix
     background: $header-color;
     overflow: hidden;
     opacity: 0;
@@ -197,7 +206,14 @@
     }
 
     .navBarLinkActive {
+        text-decoration: underline;
+        text-underline-offset: 0.7rem;
+        text-decoration-thickness: 2px;
         text-underline-offset: 0.3rem;
+
+        &::after {
+            display: none;
+        }
     }
 
     .loginBtn {

--- a/nextjs-app/src/components/Header/header.module.scss
+++ b/nextjs-app/src/components/Header/header.module.scss
@@ -82,49 +82,51 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
-        list-style: none;
-        padding: 0;
-        margin: 0;
 
-        .navItem {
-            margin: 0 $spacing-2;
-            gap: 16px;
-        }
+        list-style: none;
+
+        padding-right: $spacing-2;
+        gap: $spacing-2;
+        margin: 0;
     }
 }
 
 .loginBtn {
-    background-color: rgba(246, 244, 188, 1);
+    background-color: $btn-auth;
     border: none;
     padding: 10px 35px;
     font-weight: bold;
-    color: black;
+    color: $font-color-main;
     border-radius: 20px;
     cursor: pointer;
     transition: 0.5s;
 
     &:hover {
         text-shadow: 1px 0 0 $font-color-main;
-        background-color: #fce76c;
+        background-color: $btn-auth-hover;
     }
 }
 
 .hamburgerMenu {
+    // TODO: Looks 🤷‍♂️. Need fix
+    background: $header-color;
+    border-top: 0.1rem solid rgba(0, 0, 0, 0.5);
+
     display: none;
+    overflow: hidden;
+    opacity: 0;
+
     position: absolute;
     top: 100%;
     left: 0;
     width: 100%;
-    border-top: 0.1rem solid rgba(0, 0, 0, 0.5);
-    // TODO: Looks 🤷‍♂️. Need fix
-    background: $header-color;
-    overflow: hidden;
-    opacity: 0;
     max-height: 0;
+
     transition:
         opacity 0.7s ease-in-out,
         max-height 0.7s ease-in-out;
     z-index: 100;
+
 
     &.open {
         opacity: 1;
@@ -136,11 +138,14 @@
         padding: 0;
         margin: 0;
 
+
         .navItem {
             width: 100%;
             text-align: center;
 
+            // Link styles for hamburger menu
             a {
+                font-weight: 500;
                 display: block;
                 width: 100%;
                 padding: $spacing-1 0;
@@ -173,11 +178,16 @@
 
 @media (max-width: $lg) {
     .wrapper {
-        font-size: 65%;
+        font-size: 90%;
+    }
+
+    .navList {
+        padding-right: $spacing-1;
+        gap: $spacing-1
     }
 
     .title {
-        font-size: 0.7rem;
+        font-size: 0.8rem;
     }
 }
 
@@ -224,6 +234,6 @@
 
 @media (max-width: $sm) {
     .title {
-        font-size: 0.6rem;
+        font-size: 0.7rem;
     }
 }


### PR DESCRIPTION
Змінено:
- Підкреслення активних лінок змінено з `text-decoration: underline` на використання псевдоелементу `::after` та підкреслення блоку тексту.
- - Tradeof: при зміні вирівнювання тексту в `<li></li>` елементах на center працює некоректно. (В даний момент вирівнювання по лівому краю).
- Для хедеру десктопної версії врахував пораду. Додав `padding-right` до стиля списку в навбарі, + вказав `gap` для елементів списку. 